### PR TITLE
feat: Allow inactive search border customization

### DIFF
--- a/src/components/header/Search/Search.tsx
+++ b/src/components/header/Search/Search.tsx
@@ -108,11 +108,11 @@ const styles = stylesheet.create({
     padding: 'var(--epr-search-input-padding)',
     height: 'var(--epr-search-input-height)',
     backgroundColor: 'var(--epr-search-input-bg-color)',
-    border: '1px solid var(--epr-search-input-bg-color)',
+    border: '1px solid var(--epr-search-border-color)',
     width: '100%',
     ':focus': {
       backgroundColor: 'var(--epr-search-input-bg-color-active)',
-      border: '1px solid var(--epr-search-border-color)'
+      border: '1px solid var(--epr-search-border-color-active)'
     },
     '::placeholder': {
       color: 'var(--epr-search-input-placeholder-color)'

--- a/src/components/main/PickerMain.tsx
+++ b/src/components/main/PickerMain.tsx
@@ -142,7 +142,6 @@ const styles = stylesheet.create({
       '--epr-picker-border-radius': '8px',
 
       /* Header */
-      '--epr-search-border-color': 'var(--epr-highlight-color)',
       '--epr-header-padding': '15px var(--epr-horizontal-padding)',
 
       /* Skin Tone Picker */
@@ -158,6 +157,8 @@ const styles = stylesheet.create({
       '--epr-search-input-text-color': 'var(--epr-text-color)',
       '--epr-search-input-placeholder-color': 'var(--epr-text-color)',
       '--epr-search-bar-inner-padding': 'var(--epr-horizontal-padding)',
+      '--epr-search-border-color': 'var(--epr-search-input-bg-color)',
+      '--epr-search-border-color-active': 'var(--epr-highlight-color)',
 
       /*  Category Navigation */
       '--epr-category-navigation-button-size': '30px',


### PR DESCRIPTION
I wanted to customize the border of the search input when it's not active to achieve a Slack-like style with the input background being the same color as the picker background and a border to identify the input:

<img width="357" height="412" alt="image" src="https://github.com/user-attachments/assets/c5485752-8eb6-471d-91c1-aa1e79bf59a0" />

Unfortunately it is not possible at the moment, as it uses the search background color `--epr-search-input-bg-color`.

This PR introduces a separate variable for the input border color depending on state: one when it's inactive, and another one when it is active.

I have made the default, inactive border color default to `--epr-search-input-bg-color`, which is the previous behaviour. The newly introduced `--epr-search-border-color-active` defaults to `--epr-highlight-color`, which is the color that was used when focused previously.