### PR TITLE
Place customizer CSS under preview and scope output to aside.EmojiPickerReact

### DIFF
--- a/src/components/PickerCustomizer.tsx
+++ b/src/components/PickerCustomizer.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+import Picker, { Theme } from "emoji-picker-react";
+import React, { useMemo, useState } from "react";
+import styles from "@/styles/PickerCustomizer.module.css";
+
+const variableSections = [
+  {
+    title: "General",
+    items: [
+      {
+        label: "Emoji size",
+        variable: "--epr-emoji-size",
+        defaultValue: "30px",
+      },
+      {
+        label: "Emoji padding",
+        variable: "--epr-emoji-padding",
+        defaultValue: "5px",
+      },
+      {
+        label: "Picker background color",
+        variable: "--epr-bg-color",
+        defaultValue: "#fff",
+      },
+      {
+        label: "Text color",
+        variable: "--epr-text-color",
+        defaultValue: "#858585",
+      },
+      {
+        label: "Picker border color",
+        variable: "--epr-picker-border-color",
+        defaultValue: "#e7e7e7",
+      },
+      {
+        label: "Picker border radius",
+        variable: "--epr-picker-border-radius",
+        defaultValue: "8px",
+      },
+      {
+        label: "Horizontal padding",
+        variable: "--epr-horizontal-padding",
+        defaultValue: "10px",
+      },
+      {
+        label: "Highlight color",
+        variable: "--epr-highlight-color",
+        defaultValue: "#007aeb",
+      },
+      {
+        label: "Hover background color",
+        variable: "--epr-hover-bg-color",
+        defaultValue: "#e5f0fa",
+      },
+      {
+        label: "Focus background color",
+        variable: "--epr-focus-bg-color",
+        defaultValue: "#e0f0ff",
+      },
+    ],
+  },
+  {
+    title: "Search input",
+    items: [
+      {
+        label: "Search background color",
+        variable: "--epr-search-input-bg-color",
+        defaultValue: "#f6f6f6",
+      },
+      {
+        label: "Search active background color",
+        variable: "--epr-search-input-bg-color-active",
+        defaultValue: "var(--epr-search-input-bg-color)",
+      },
+      {
+        label: "Search text color",
+        variable: "--epr-search-input-text-color",
+        defaultValue: "var(--epr-text-color)",
+      },
+      {
+        label: "Search placeholder color",
+        variable: "--epr-search-input-placeholder-color",
+        defaultValue: "var(--epr-text-color)",
+      },
+      {
+        label: "Search border color",
+        variable: "--epr-search-border-color",
+        defaultValue: "var(--epr-search-input-bg-color)",
+      },
+      {
+        label: "Search border color (active)",
+        variable: "--epr-search-border-color-active",
+        defaultValue: "var(--epr-highlight-color)",
+      },
+      {
+        label: "Search border radius",
+        variable: "--epr-search-input-border-radius",
+        defaultValue: "8px",
+      },
+      {
+        label: "Search input height",
+        variable: "--epr-search-input-height",
+        defaultValue: "40px",
+      },
+      {
+        label: "Search icon color",
+        variable: "--epr-search-icon-color",
+        defaultValue: "",
+      },
+    ],
+  },
+  {
+    title: "Category navigation",
+    items: [
+      {
+        label: "Category button size",
+        variable: "--epr-category-navigation-button-size",
+        defaultValue: "30px",
+      },
+      {
+        label: "Active category icon color",
+        variable: "--epr-category-icon-active-color",
+        defaultValue: "#6aa8de",
+      },
+    ],
+  },
+  {
+    title: "Category labels",
+    items: [
+      {
+        label: "Category label background color",
+        variable: "--epr-category-label-bg-color",
+        defaultValue: "#ffffffe6",
+      },
+      {
+        label: "Category label text color",
+        variable: "--epr-category-label-text-color",
+        defaultValue: "var(--epr-text-color)",
+      },
+      {
+        label: "Category label height",
+        variable: "--epr-category-label-height",
+        defaultValue: "40px",
+      },
+    ],
+  },
+  {
+    title: "Preview area",
+    items: [
+      {
+        label: "Preview height",
+        variable: "--epr-preview-height",
+        defaultValue: "70px",
+      },
+      {
+        label: "Preview text size",
+        variable: "--epr-preview-text-size",
+        defaultValue: "14px",
+      },
+      {
+        label: "Preview text color",
+        variable: "--epr-preview-text-color",
+        defaultValue: "var(--epr-text-color)",
+      },
+    ],
+  },
+  {
+    title: "Skin tone picker",
+    items: [
+      {
+        label: "Skin tone menu color",
+        variable: "--epr-skin-tone-picker-menu-color",
+        defaultValue: "#ffffff95",
+      },
+      {
+        label: "Skin tone size",
+        variable: "--epr-skin-tone-size",
+        defaultValue: "20px",
+      },
+    ],
+  },
+  {
+    title: "Dark mode",
+    items: [
+      {
+        label: "Dark background color",
+        variable: "--epr-dark-bg-color",
+        defaultValue: "#222222",
+      },
+      {
+        label: "Dark border color",
+        variable: "--epr-dark-picker-border-color",
+        defaultValue: "#151617",
+      },
+      {
+        label: "Dark text color",
+        variable: "--epr-dark-text-color",
+        defaultValue: "var(--epr-highlight-color)",
+      },
+      {
+        label: "Dark search background",
+        variable: "--epr-dark-search-input-bg-color",
+        defaultValue: "#333333",
+      },
+      {
+        label: "Dark hover background",
+        variable: "--epr-dark-hover-bg-color",
+        defaultValue: "#363636f6",
+      },
+    ],
+  },
+];
+
+type VariableState = {
+  enabled: boolean;
+  value: string;
+};
+
+type VariableConfig = (typeof variableSections)[number]["items"][number];
+
+type VariableStateMap = Record<string, VariableState>;
+
+const initialState: VariableStateMap = variableSections
+  .flatMap((section) => section.items)
+  .reduce<VariableStateMap>((acc, item) => {
+    acc[item.variable] = {
+      value: item.defaultValue,
+      enabled: false,
+    };
+    return acc;
+  }, {});
+
+const colorValueRegex = /^#([0-9a-f]{3}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
+export function PickerCustomizer() {
+  const [variableValues, setVariableValues] = useState<VariableStateMap>(
+    initialState,
+  );
+
+  const enabledEntries = useMemo(() => {
+    return Object.entries(variableValues)
+      .filter(([, state]) => state.enabled)
+      .map(([variable, state]) => [variable, state.value]);
+  }, [variableValues]);
+
+  const pickerStyle = useMemo(() => {
+    return enabledEntries.reduce<Record<string, string>>((acc, [key, value]) => {
+      acc[key] = value;
+      return acc;
+    }, {});
+  }, [enabledEntries]);
+
+  const cssSnippet = useMemo(() => {
+    return enabledEntries;
+  }, [enabledEntries]);
+
+  const cssOutputString = useMemo(() => {
+    if (!enabledEntries.length) {
+      return "aside.EmojiPickerReact {\n  /* Toggle variables to output CSS */\n}\n";
+    }
+
+    const lines = enabledEntries.map(
+      ([variable, value]) => `  ${variable}: ${value};`,
+    );
+    return ["aside.EmojiPickerReact {", ...lines, "}", ""].join("\n");
+  }, [enabledEntries]);
+
+  return (
+    <div className={styles.customizer}>
+      <div className={styles.customizerHeader}>
+        <div>
+          <div className={styles.customizerTitle}>
+            Customize how the picker looks
+          </div>
+          <div className={styles.customizerSummaryHint}>
+            Toggle the variables you want to override.
+          </div>
+        </div>
+      </div>
+      <div className={styles.customizerBody}>
+        <div className={styles.customizerLayout}>
+          <form className={styles.customizerForm}>
+            {variableSections.map((section) => (
+              <details className={styles.section} key={section.title}>
+                <summary className={styles.sectionSummary}>
+                  <span className={styles.sectionTitle}>{section.title}</span>
+                  <span className={styles.sectionHint}>
+                    {section.items.length} variables
+                  </span>
+                </summary>
+                <div className={styles.sectionGrid}>
+                  {section.items.map((item) => (
+                    <VariableControl
+                      key={item.variable}
+                      item={item}
+                      state={variableValues[item.variable]}
+                      onToggle={(enabled) =>
+                        setVariableValues((prev) => ({
+                          ...prev,
+                          [item.variable]: {
+                            ...prev[item.variable],
+                            enabled,
+                          },
+                        }))
+                      }
+                      onChange={(value) =>
+                        setVariableValues((prev) => ({
+                          ...prev,
+                          [item.variable]: {
+                            ...prev[item.variable],
+                            value,
+                          },
+                        }))
+                      }
+                    />
+                  ))}
+                </div>
+              </details>
+            ))}
+          </form>
+
+          <div className={styles.previewSection}>
+            <div className={styles.previewHeader}>Live preview</div>
+            <div className={styles.previewWrapper} style={pickerStyle}>
+              <Picker
+                theme={Theme.AUTO}
+                height={360}
+                width={320}
+                searchDisabled={false}
+                previewConfig={{
+                  showPreview: true,
+                  defaultEmoji: "1f60a",
+                  defaultCaption: "How it feels",
+                }}
+              />
+            </div>
+
+            <div className={styles.outputSection}>
+              <div className={styles.outputHeader}>
+                <span>CSS output</span>
+                <button
+                  type="button"
+                  className={styles.copyButton}
+                  onClick={() => navigator.clipboard.writeText(cssOutputString)}
+                >
+                  Copy CSS
+                </button>
+              </div>
+              <pre className={styles.outputCode}>
+                <code>
+                  <span className={styles.codeBrace}>
+                    aside.EmojiPickerReact {"{"}
+                  </span>
+                  {cssSnippet.length === 0 ? (
+                    <span className={styles.codeComment}>
+                      {"\n"}  {"/* Toggle variables to output CSS */"}
+                    </span>
+                  ) : (
+                    cssSnippet.map(([variable, value]) => (
+                      <span className={styles.codeLine} key={variable}>
+                        {"\n"}  <span className={styles.codeVariable}>{variable}</span>
+                        {": "}
+                        <span className={styles.codeValue}>{value}</span>;
+                      </span>
+                    ))
+                  )}
+                  {"\n"}
+                  <span className={styles.codeBrace}>{"}"}</span>
+                </code>
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function VariableControl({
+  item,
+  state,
+  onToggle,
+  onChange,
+}: {
+  item: VariableConfig;
+  state: VariableState;
+  onToggle: (enabled: boolean) => void;
+  onChange: (value: string) => void;
+}) {
+  const colorFallback = colorValueRegex.test(item.defaultValue)
+    ? item.defaultValue
+    : "#ffffff";
+  const colorValue = colorValueRegex.test(state.value)
+    ? state.value
+    : colorFallback;
+
+  return (
+    <div className={styles.variableRow}>
+      <label className={styles.variableLabel}>
+        <input
+          type="checkbox"
+          checked={state.enabled}
+          onChange={(event) => onToggle(event.target.checked)}
+        />
+        <span className={styles.variableName}>{item.label}</span>
+        <span className={styles.variableToken}>{item.variable}</span>
+      </label>
+      <div className={styles.variableControls}>
+        {colorValueRegex.test(item.defaultValue) && (
+          <input
+            type="color"
+            value={colorValue}
+            disabled={!state.enabled}
+            onChange={(event) => onChange(event.target.value)}
+            aria-label={`${item.label} color`}
+          />
+        )}
+        <input
+          type="text"
+          value={state.value}
+          disabled={!state.enabled}
+          onChange={(event) => onChange(event.target.value)}
+          placeholder={item.defaultValue || "e.g. 12px"}
+          aria-label={`${item.label} value`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/PickerDemo.tsx
+++ b/src/components/PickerDemo.tsx
@@ -9,6 +9,7 @@ import Picker, {
 import { EmojiStyle, PickerProps } from "emoji-picker-react";
 import React, { useState } from "react";
 import { PickerControls } from "./PickerControls";
+import { PickerCustomizer } from "./PickerCustomizer";
 import styles from "@/styles/PickerDemo.module.css";
 
 const DEFAULT_SKIN_TONES_DISABLED = false;
@@ -37,47 +38,77 @@ export default function PickerDemo() {
   const [pickerProps, setPickerProps] = useState<PickerProps>(defaultProps);
   const [now, setNow] = useState(Date.now());
   const [textareaValue, setTextareaValue] = useState("");
+  const [activeTab, setActiveTab] = useState<"playground" | "customize">(
+    "playground",
+  );
 
   return (
     <div className={styles.pickerDemoWrapper}>
-      <div className={styles.pickerDemo}>
-        <PickerControls
-          pickerProps={pickerProps}
-          updateState={updateState}
-          reset={resetState}
-        />
-        <div className={styles.pickerColumn}>
-          <div className={styles.pickerWrapper}>
-            <Picker
-              onEmojiClick={(emoji) =>
-                setTextareaValue(
-                  (tv) =>
-                    tv + (emoji?.isCustom ? `:${emoji.emoji}:` : emoji.emoji),
-                )
-              }
-              key={now}
-              {...pickerProps}
+      <div className={styles.tabBar}>
+        <button
+          className={`${styles.tabButton} ${
+            activeTab === "playground" ? styles.tabButtonActive : ""
+          }`}
+          type="button"
+          onClick={() => setActiveTab("playground")}
+        >
+          Playground
+        </button>
+        <button
+          className={`${styles.tabButton} ${
+            activeTab === "customize" ? styles.tabButtonActive : ""
+          }`}
+          type="button"
+          onClick={() => setActiveTab("customize")}
+        >
+          Customize
+        </button>
+      </div>
+
+      {activeTab === "playground" ? (
+        <div className={styles.pickerDemo}>
+          <div className={styles.controlsColumn}>
+            <PickerControls
+              pickerProps={pickerProps}
+              updateState={updateState}
+              reset={resetState}
             />
           </div>
-          <div className={styles.outputSection}>
-            <div className={styles.outputHeader}>
-              <span className={styles.outputLabel}>Output</span>
-              <button
-                className={styles.copyOutputButton}
-                onClick={() => navigator.clipboard.writeText(textareaValue)}
-              >
-                Copy
-              </button>
+          <div className={styles.pickerColumn}>
+            <div className={styles.pickerWrapper}>
+              <Picker
+                onEmojiClick={(emoji) =>
+                  setTextareaValue(
+                    (tv) =>
+                      tv + (emoji?.isCustom ? `:${emoji.emoji}:` : emoji.emoji),
+                  )
+                }
+                key={now}
+                {...pickerProps}
+              />
             </div>
-            <textarea
-              value={textareaValue}
-              onChange={(e) => setTextareaValue(e.target.value)}
-              placeholder="Click any emoji to add it here..."
-              className={styles.pickerTextarea}
-            ></textarea>
+            <div className={styles.outputSection}>
+              <div className={styles.outputHeader}>
+                <span className={styles.outputLabel}>Output</span>
+                <button
+                  className={styles.copyOutputButton}
+                  onClick={() => navigator.clipboard.writeText(textareaValue)}
+                >
+                  Copy
+                </button>
+              </div>
+              <textarea
+                value={textareaValue}
+                onChange={(e) => setTextareaValue(e.target.value)}
+                placeholder="Click any emoji to add it here..."
+                className={styles.pickerTextarea}
+              ></textarea>
+            </div>
           </div>
         </div>
-      </div>
+      ) : (
+        <PickerCustomizer />
+      )}
     </div>
   );
 

--- a/src/styles/PickerCustomizer.module.css
+++ b/src/styles/PickerCustomizer.module.css
@@ -1,0 +1,273 @@
+.customizer {
+  width: 100%;
+  background: var(--surface);
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  overflow: hidden;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.05);
+}
+
+@media (max-width: 900px) {
+  .customizer {
+    width: 100%;
+  }
+}
+
+.customizerHeader {
+  padding: 1.25rem 1.5rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.customizerTitle {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.customizerSummaryHint {
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--foreground-muted);
+  margin-top: 0.25rem;
+}
+
+.customizerBody {
+  padding: 1.25rem 1.5rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.customizerLayout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+@media (max-width: 900px) {
+  .customizerLayout {
+    grid-template-columns: 1fr;
+  }
+}
+
+.customizerForm {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.section {
+  border: 1px solid var(--border-subtle);
+  border-radius: 10px;
+  background: var(--background);
+  overflow: hidden;
+}
+
+.sectionSummary {
+  list-style: none;
+  cursor: pointer;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: var(--surface);
+  position: relative;
+}
+
+.sectionSummary::-webkit-details-marker {
+  display: none;
+}
+
+.sectionSummary::after {
+  content: "▸";
+  color: var(--foreground-muted);
+  font-size: 0.8rem;
+  margin-left: auto;
+  transition: transform 0.2s ease;
+}
+
+.section[open] .sectionSummary::after {
+  transform: rotate(90deg);
+}
+
+.sectionTitle {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--foreground-muted);
+  margin: 0;
+}
+
+.sectionHint {
+  font-size: 0.65rem;
+  color: var(--foreground-muted);
+}
+
+.sectionGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 0.75rem 0.9rem 0.9rem;
+}
+
+.variableRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.variableRow:last-child {
+  border-bottom: none;
+}
+
+.variableLabel {
+  display: grid;
+  grid-template-columns: 16px 1fr;
+  gap: 0.5rem;
+  align-items: center;
+  font-size: 0.8rem;
+  color: var(--foreground);
+}
+
+.variableLabel input[type="checkbox"] {
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+.variableName {
+  font-weight: 500;
+}
+
+.variableToken {
+  font-size: 0.7rem;
+  color: var(--foreground-muted);
+  grid-column: 2;
+}
+
+.variableControls {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.variableControls input[type="text"] {
+  flex: 1;
+  min-width: 140px;
+  padding: 0.4rem 0.5rem;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--background);
+  color: var(--foreground);
+  font-size: 0.75rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.variableControls input[type="color"] {
+  width: 36px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+}
+
+.variableControls input[type="text"]:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-subtle);
+  outline: none;
+}
+
+.variableControls input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.previewSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.previewHeader {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.previewWrapper {
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--background);
+}
+
+.outputSection {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.outputHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--foreground);
+}
+
+.copyButton {
+  font-size: 0.7rem;
+  color: var(--foreground-muted);
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.copyButton:hover {
+  color: var(--foreground);
+  border-color: var(--foreground-muted);
+}
+
+.outputCode {
+  margin: 0;
+  background: var(--surface-hover);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 0.72rem;
+  line-height: 1.5;
+  color: var(--foreground);
+  overflow-x: auto;
+  border: 1px solid var(--border-subtle);
+}
+
+.codeLine {
+  display: block;
+}
+
+.codeBrace {
+  color: var(--foreground);
+  font-weight: 600;
+}
+
+.codeVariable {
+  color: #6aa8de;
+}
+
+.codeValue {
+  color: #e56d90;
+}
+
+.codeComment {
+  color: var(--foreground-muted);
+}

--- a/src/styles/PickerCustomizer.module.css
+++ b/src/styles/PickerCustomizer.module.css
@@ -16,6 +16,9 @@
 .customizerHeader {
   padding: 1.25rem 1.5rem 0.5rem;
   border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
 }
 
 .customizerTitle {
@@ -29,6 +32,27 @@
   font-weight: 500;
   color: var(--foreground-muted);
   margin-top: 0.25rem;
+}
+
+.resetButton {
+  font-size: 0.6875rem;
+  color: var(--foreground-muted);
+  background: var(--background);
+  border: 1px solid var(--border);
+  cursor: pointer;
+  padding: 0.375rem 0.625rem;
+  border-radius: 5px;
+  transition: all 0.15s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.resetButton:hover {
+  color: var(--foreground);
+  border-color: var(--foreground-muted);
 }
 
 .customizerBody {
@@ -164,7 +188,9 @@
   background: var(--background);
   color: var(--foreground);
   font-size: 0.75rem;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease;
 }
 
 .variableControls input[type="color"] {

--- a/src/styles/PickerDemo.module.css
+++ b/src/styles/PickerDemo.module.css
@@ -1,6 +1,9 @@
 .pickerDemoWrapper {
   max-width: var(--max-width);
   margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 
 .tabBar {

--- a/src/styles/PickerDemo.module.css
+++ b/src/styles/PickerDemo.module.css
@@ -3,11 +3,50 @@
   margin: 0 auto;
 }
 
+.tabBar {
+  display: inline-flex;
+  gap: 0.5rem;
+  padding: 0.35rem;
+  border-radius: 999px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  margin-bottom: 1.5rem;
+}
+
+.tabButton {
+  border: none;
+  background: transparent;
+  color: var(--foreground-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.tabButton:hover {
+  color: var(--foreground);
+}
+
+.tabButtonActive {
+  background: var(--surface-hover);
+  color: var(--foreground);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+
 .pickerDemo {
   display: flex;
   gap: 1.5rem;
   align-items: flex-start;
   justify-content: center;
+}
+
+.controlsColumn {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  align-items: stretch;
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- The CSS output panel should live beneath the live picker so it only applies visually to the preview column and no longer stretches across both columns.
- The generated CSS should be more specific to avoid accidental global overrides by targeting the picker root element selector.

### Description
- Moved the CSS output block into the preview column in `src/components/PickerCustomizer.tsx` so the code panel appears under the live preview instead of spanning the whole layout.
- Updated the generated CSS to use the more specific selector `aside.EmojiPickerReact` in `PickerCustomizer.tsx` and updated the displayed snippet accordingly.
- Adjusted styles in `src/styles/PickerCustomizer.module.css` (removed sticky top behavior and added spacing) to accommodate the new output placement.
- Staged and committed the changes to `src/components/PickerCustomizer.tsx` and `src/styles/PickerCustomizer.module.css`.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which compiled successfully but emitted runtime SSR warnings about `useLayoutEffect` (these are existing warnings and not caused by this change).
- Ran a Playwright script that opened `http://127.0.0.1:3000/#playground`, switched to the `Customize` tab, expanded the `General` section, and saved a screenshot to `artifacts/customizer-css-below-picker.png`, which completed successfully.
- No automated unit tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69884311fccc8330b1ea2c85e4dfe323)