### PR TITLE
Fix button text contrast in dark mode

### DIFF
--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -70,7 +70,7 @@
   padding: 0.5rem 0.875rem;
   font-size: 0.875rem;
   font-weight: 500;
-  color: white;
+  color: var(--background);
   background: var(--foreground);
   border-radius: 6px;
   border: none;
@@ -200,7 +200,7 @@
   padding: 0.75rem 1.5rem;
   font-size: 0.9375rem;
   font-weight: 500;
-  color: white;
+  color: var(--background);
   background: var(--foreground);
   border-radius: 8px;
   border: none;


### PR DESCRIPTION
### Motivation
- Buttons used a hardcoded `white` text color which produced low contrast on the dark theme for the header GitHub button and the hero "Try it out" primary button.

### Description
- Replace `color: white` with `color: var(--background)` in `src/styles/Home.module.css` for the `.navButton` and `.primaryButton` selectors so the text uses the theme background color and improves contrast.

### Testing
- Started the dev server with `npm run dev`, rendered the page in dark mode via Playwright and captured a screenshot, and Next compiled successfully allowing visual verification of the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a359a6c6c83308023297983e7e776)