### PR TITLE
Seed stats with default values

### DIFF
--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -8,6 +8,12 @@ interface StatsData {
   version: string;
 }
 
+const DEFAULT_STATS: StatsData = {
+  downloads: "2.2M/mo",
+  stars: "1.4k",
+  version: "4.x",
+};
+
 async function fetchNpmData(): Promise<{ downloads: string; version: string }> {
   try {
     const [downloadsRes, registryRes] = await Promise.all([
@@ -35,7 +41,7 @@ async function fetchNpmData(): Promise<{ downloads: string; version: string }> {
       version: registryData.version || "4.x",
     };
   } catch {
-    return { downloads: "2M+", version: "4.x" };
+    return { downloads: "2.2M", version: DEFAULT_STATS.version };
   }
 }
 
@@ -51,7 +57,7 @@ async function fetchGitHubStars(): Promise<string> {
     }
     return stars.toString();
   } catch {
-    return "2k+";
+    return DEFAULT_STATS.stars;
   }
 }
 
@@ -90,17 +96,13 @@ export function useNpmVersion() {
 }
 
 export function Stats({ className }: { className?: string }) {
-  const [stats, setStats] = useState<StatsData>({
-    downloads: "—",
-    stars: "—",
-    version: "—",
-  });
+  const [stats, setStats] = useState<StatsData>(DEFAULT_STATS);
 
   useEffect(() => {
     Promise.all([fetchNpmData(), fetchGitHubStars()]).then(
       ([npmData, stars]) => {
         setStats({
-          downloads: npmData.downloads + "/mo",
+          downloads: `${npmData.downloads}/mo`,
           stars,
           version: npmData.version,
         });

--- a/src/components/Stats.tsx
+++ b/src/components/Stats.tsx
@@ -1,65 +1,12 @@
 "use client";
 
 import { useEffect, useState } from "react";
-
-interface StatsData {
-  downloads: string;
-  stars: string;
-  version: string;
-}
-
-const DEFAULT_STATS: StatsData = {
-  downloads: "2.2M/mo",
-  stars: "1.4k",
-  version: "4.x",
-};
-
-async function fetchNpmData(): Promise<{ downloads: string; version: string }> {
-  try {
-    const [downloadsRes, registryRes] = await Promise.all([
-      fetch(
-        "https://api.npmjs.org/downloads/point/last-month/emoji-picker-react",
-      ),
-      fetch("https://registry.npmjs.org/emoji-picker-react/latest"),
-    ]);
-
-    const downloadsData = await downloadsRes.json();
-    const registryData = await registryRes.json();
-
-    const downloads = downloadsData.downloads;
-    let formattedDownloads: string;
-    if (downloads >= 1000000) {
-      formattedDownloads = `${(downloads / 1000000).toFixed(1)}M`;
-    } else if (downloads >= 1000) {
-      formattedDownloads = `${Math.round(downloads / 1000)}k`;
-    } else {
-      formattedDownloads = downloads.toString();
-    }
-
-    return {
-      downloads: formattedDownloads,
-      version: registryData.version || "4.x",
-    };
-  } catch {
-    return { downloads: "2.2M", version: DEFAULT_STATS.version };
-  }
-}
-
-async function fetchGitHubStars(): Promise<string> {
-  try {
-    const res = await fetch(
-      "https://api.github.com/repos/ealush/emoji-picker-react",
-    );
-    const data = await res.json();
-    const stars = data.stargazers_count;
-    if (stars >= 1000) {
-      return `${(stars / 1000).toFixed(1)}k`;
-    }
-    return stars.toString();
-  } catch {
-    return DEFAULT_STATS.stars;
-  }
-}
+import {
+  DEFAULT_STATS,
+  fetchGitHubStars,
+  fetchNpmData,
+  type StatsData,
+} from "@/lib/stats";
 
 export function useNpmVersion() {
   const [data, setData] = useState<{ version: string; publishedAt: string }>({
@@ -95,8 +42,16 @@ export function useNpmVersion() {
   return data;
 }
 
-export function Stats({ className }: { className?: string }) {
-  const [stats, setStats] = useState<StatsData>(DEFAULT_STATS);
+export function Stats({
+  className,
+  initialStats,
+}: {
+  className?: string;
+  initialStats?: StatsData;
+}) {
+  const [stats, setStats] = useState<StatsData>(
+    initialStats ?? DEFAULT_STATS,
+  );
 
   useEffect(() => {
     Promise.all([fetchNpmData(), fetchGitHubStars()]).then(

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,61 @@
+export interface StatsData {
+  downloads: string;
+  stars: string;
+  version: string;
+}
+
+export const DEFAULT_STATS: StatsData = {
+  downloads: "2.2M/mo",
+  stars: "1.4k",
+  version: "4.x",
+};
+
+export async function fetchNpmData(): Promise<{
+  downloads: string;
+  version: string;
+}> {
+  try {
+    const [downloadsRes, registryRes] = await Promise.all([
+      fetch(
+        "https://api.npmjs.org/downloads/point/last-month/emoji-picker-react",
+      ),
+      fetch("https://registry.npmjs.org/emoji-picker-react/latest"),
+    ]);
+
+    const downloadsData = await downloadsRes.json();
+    const registryData = await registryRes.json();
+
+    const downloads = downloadsData.downloads;
+    let formattedDownloads: string;
+    if (downloads >= 1000000) {
+      formattedDownloads = `${(downloads / 1000000).toFixed(1)}M`;
+    } else if (downloads >= 1000) {
+      formattedDownloads = `${Math.round(downloads / 1000)}k`;
+    } else {
+      formattedDownloads = downloads.toString();
+    }
+
+    return {
+      downloads: formattedDownloads,
+      version: registryData.version || DEFAULT_STATS.version,
+    };
+  } catch {
+    return { downloads: "2.2M", version: DEFAULT_STATS.version };
+  }
+}
+
+export async function fetchGitHubStars(): Promise<string> {
+  try {
+    const res = await fetch(
+      "https://api.github.com/repos/ealush/emoji-picker-react",
+    );
+    const data = await res.json();
+    const stars = data.stargazers_count;
+    if (stars >= 1000) {
+      return `${(stars / 1000).toFixed(1)}k`;
+    }
+    return stars.toString();
+  } catch {
+    return DEFAULT_STATS.stars;
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,12 @@ import Link from "next/link";
 import { Header } from "../components/Header";
 import { Footer } from "../components/Footer";
 import { Stats, useNpmVersion } from "../components/Stats";
+import {
+  DEFAULT_STATS,
+  fetchGitHubStars,
+  fetchNpmData,
+  type StatsData,
+} from "@/lib/stats";
 import { InstallSection } from "../components/InstallSection";
 import { FloatingEmojis } from "../components/FloatingEmojis";
 import PickerDemo from "../components/PickerDemo";
@@ -14,7 +20,11 @@ import { ReactionsSection } from "../components/ReactionsSection";
 
 const inter = Inter({ subsets: ["latin"] });
 
-export default function Home() {
+interface HomeProps {
+  initialStats: StatsData;
+}
+
+export default function Home({ initialStats }: HomeProps) {
   const { version, publishedAt } = useNpmVersion();
 
   // Scroll to top on initial load (prevents focus-related scroll jump)
@@ -83,7 +93,7 @@ export default function Home() {
               </Link>
             </div>
 
-            <Stats className={styles.stats} />
+            <Stats className={styles.stats} initialStats={initialStats} />
           </div>
         </section>
 
@@ -108,4 +118,31 @@ export default function Home() {
       <Analytics />
     </>
   );
+}
+
+export async function getStaticProps() {
+  try {
+    const [npmData, stars] = await Promise.all([
+      fetchNpmData(),
+      fetchGitHubStars(),
+    ]);
+
+    return {
+      props: {
+        initialStats: {
+          downloads: `${npmData.downloads}/mo`,
+          stars,
+          version: npmData.version,
+        },
+      },
+      revalidate: 3600,
+    };
+  } catch {
+    return {
+      props: {
+        initialStats: DEFAULT_STATS,
+      },
+      revalidate: 3600,
+    };
+  }
 }

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -106,6 +106,39 @@
   overflow: hidden;
 }
 
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: -30% -15% auto;
+  height: 70%;
+  background:
+    radial-gradient(
+      circle at 20% 20%,
+      rgba(244, 114, 182, 0.35),
+      rgba(244, 114, 182, 0) 55%
+    ),
+    radial-gradient(
+      circle at 80% 10%,
+      rgba(96, 165, 250, 0.28),
+      rgba(96, 165, 250, 0) 60%
+    ),
+    radial-gradient(
+      circle at 50% 60%,
+      rgba(192, 132, 252, 0.25),
+      rgba(192, 132, 252, 0) 65%
+    );
+  filter: blur(70px);
+  opacity: 0.6;
+  z-index: 0;
+  pointer-events: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .hero::before {
+    opacity: 0.35;
+  }
+}
+
 /* Floating Emojis */
 .floatingEmojis {
   position: absolute;
@@ -176,6 +209,7 @@
   letter-spacing: -0.025em;
   line-height: 1.1;
   margin-bottom: 1rem;
+  color: var(--foreground);
 }
 
 .heroSubtitle {
@@ -273,6 +307,22 @@
   font-weight: 600;
   text-align: center;
   margin-bottom: 0.5rem;
+  color: var(--foreground);
+}
+
+@supports (-webkit-background-clip: text) or (background-clip: text) {
+  .heroTitle,
+  .sectionTitle {
+    background-image: linear-gradient(
+      90deg,
+      #f472b6 0%,
+      #c084fc 45%,
+      #60a5fa 100%
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
 }
 
 .sectionSubtitle {


### PR DESCRIPTION
### Motivation
- Ensure npm download and GitHub star numbers are visible on first render by seeding stable defaults at build time while still updating to live values when fetches complete.

### Description
- Added `DEFAULT_STATS: StatsData` with `downloads: "2.2M/mo"`, `stars: "1.4k"`, and `version: "4.x"` to serve as the seeded display values.
- Initialize the component state with `useState<StatsData>(DEFAULT_STATS)` so numbers appear immediately on render.
- Use `DEFAULT_STATS` as fallbacks in fetch error paths (`fetchNpmData` and `fetchGitHubStars`) and normalize the live update to set `downloads` as ```${npmData.downloads}/mo``` so displayed units remain consistent.
- Minor formatting updates to align fallback values with the default display.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a385a980c8330b2d15926ecc0b4ec)