### PR TITLE
Add nonce prop for csp style src compatibility

### DIFF
--- a/src/EmojiPickerReact.tsx
+++ b/src/EmojiPickerReact.tsx
@@ -18,7 +18,7 @@ import { PickerProps } from './index';
 function EmojiPicker(props: PickerProps) {
   return (
     <ElementRefContextProvider>
-      <PickerStyleTag />
+      <PickerStyleTag nonce={props.nonce} />
       <PickerConfigProvider {...props}>
         <PickerDataProvider>
           <ContentControl />

--- a/src/Stylesheet/stylesheet.tsx
+++ b/src/Stylesheet/stylesheet.tsx
@@ -20,9 +20,14 @@ export const commonStyles = stylesheet.create({
   },
 });
 
-export const PickerStyleTag = React.memo(function PickerStyleTag() {
+export const PickerStyleTag = React.memo(function PickerStyleTag({
+  nonce,
+}: {
+  nonce?: string;
+}) {
   return (
     <style
+      nonce={nonce}
       suppressHydrationWarning
       dangerouslySetInnerHTML={{ __html: stylesheet.getStyle() }}
     />

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -115,6 +115,7 @@ export function basePickerConfig(): PickerConfigInternal {
     hiddenEmojis: [],
     emojiData: undefined,
     categoryIcons: {},
+    nonce: undefined,
   };
 }
 
@@ -148,6 +149,7 @@ export type PickerConfigInternal = {
   hiddenEmojis: string[];
   emojiData?: EmojiData;
   categoryIcons: CategoryIcons;
+  nonce?: string,
 };
 
 export type PreviewConfig = {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -149,7 +149,7 @@ export type PickerConfigInternal = {
   hiddenEmojis: string[];
   emojiData?: EmojiData;
   categoryIcons: CategoryIcons;
-  nonce?: string,
+  nonce?: string;
 };
 
 export type PreviewConfig = {


### PR DESCRIPTION
## Problem
emoji-picker-react injects a <style> tag into the DOM via `flairup`.
This conflicts with strict Content-Security-Policy headers that use
`style-src 'nonce-xxx'` without `unsafe-inline`, causing the picker's
styles to be blocked by the browser.

closes #186 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional nonce support added for injected styles to improve CSP compatibility.
  
<!-- end of auto-generated comment: release notes by coderabbit.ai -->